### PR TITLE
Remove IE legacy meta tag and Google analytics script

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 
   <!-- Required meta tags -->
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!-- <meta http-equiv="X-UA-Compatible" content="IE=edge"> -->
   <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
 
   <meta name="description" content="Pingchuan Ma is a Ph.D. candidate in computer science at MIT CSAIL.">
@@ -34,23 +34,6 @@
 
   <!-- clipboard.js -->
   <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js"></script>
-
-  <!-- Google Analytics -->
-  <script>
-    (function(i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r;
-      i[r] = i[r] || function() {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date();
-      a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0];
-      a.async = 1;
-      a.src = g;
-      m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', 'UA-104092499-1', 'auto');
-    ga('send', 'pageview');
-  </script>
 
 </head>
 


### PR DESCRIPTION
- The line `<meta http-equiv="X-UA-Compatible" content="IE=edge">` is a legacy meta tag that was primarily used to control how Internet Explorer (IE) rendered web pages. 
- However, Internet Explorer is no longer actively supported by Microsoft. The last version, IE11, reached end of life on June 15, 2022. 
- Modern browsers like Chrome, Firefox, Safari, and Edge don't use this tag.
- Thus, I think we can safely remove this line because we don't need to support older versions of Internet Explorer, 
- However, if you still have a significant number of users on older IE versions, you might want to uncomment and keep it.